### PR TITLE
Update analyzer.rb

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -865,7 +865,7 @@ module Pod
           Version.new(library_spec.deployment_target(platform_name) || default)
         end.max
         if platform_name == :ios && build_type.framework?
-          minimum = Version.new('13.0')
+          minimum = Version.new('11.0')
           deployment_target = [deployment_target, minimum].max
         end
         Platform.new(platform_name, deployment_target)


### PR DESCRIPTION
MOD increased minimum deployment target to iOS 11.0 when linting proj… …ect to fix Xode 14.3 compiler errors (was iOS 8.0 before)